### PR TITLE
Add more GitHub Actions workflow for Dagger tests

### DIFF
--- a/.github/workflows/dissect-dagger.yml
+++ b/.github/workflows/dissect-dagger.yml
@@ -1,0 +1,48 @@
+name: dissect-dagger
+
+on:
+  push:
+    paths:
+      - "dissect/**"
+      - ".dagger/**"
+      - ".github/workflows/dissect-dagger.yml"
+  pull_request:
+    paths:
+      - "dissect/**"
+      - ".dagger/**"
+      - ".github/workflows/dissect-dagger.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run dissect tests with Dagger
+        uses: dagger/dagger-for-github@d809c269da643e2a9e56163b6d295c75ecb05f7a # v8.2.0
+        with:
+          version: "0.19.4"
+          verb: call
+          args: dissect-tests --format=testname
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+      - name: Display test summary
+        if: success()
+        run: |
+          {
+            echo "## ✅ Test Results"
+            echo ""
+            echo "dissect tests completed successfully using Dagger."
+            echo ""
+            echo "**Test Environment:**"
+            echo "- Container: \`golang:1.24.7\`"
+            echo "- Test runner: \`gotestsum\`"
+            echo "- Format: \`testname\`"
+            echo "- Dagger version: \`0.19.4\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/toml-dagger.yml
+++ b/.github/workflows/toml-dagger.yml
@@ -1,0 +1,48 @@
+name: toml-dagger
+
+on:
+  push:
+    paths:
+      - "lib/toml/**"
+      - ".dagger/**"
+      - ".github/workflows/toml-dagger.yml"
+  pull_request:
+    paths:
+      - "lib/toml/**"
+      - ".dagger/**"
+      - ".github/workflows/toml-dagger.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run toml tests with Dagger
+        uses: dagger/dagger-for-github@d809c269da643e2a9e56163b6d295c75ecb05f7a # v8.2.0
+        with:
+          version: "0.19.4"
+          verb: call
+          args: toml-tests --format=testname
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+      - name: Display test summary
+        if: success()
+        run: |
+          {
+            echo "## ✅ Test Results"
+            echo ""
+            echo "lib/toml tests completed successfully using Dagger."
+            echo ""
+            echo "**Test Environment:**"
+            echo "- Container: \`golang:1.24.7\`"
+            echo "- Test runner: \`gotestsum\`"
+            echo "- Format: \`testname\`"
+            echo "- Dagger version: \`0.19.4\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
- Add dissect-dagger.yml workflow to run dissect tests using Dagger
- Add toml-dagger.yml workflow to run lib/toml tests using Dagger
- Both workflows use dagger-for-github action v8.2.0
- Both workflows trigger on push/PR changes to their respective directories
- Tests run in golang:1.24.7 container with gotestsum