### PR TITLE
tk: Fix project listing to show names instead of IDs

### DIFF
--- a/tk/utils.go
+++ b/tk/utils.go
@@ -32,8 +32,16 @@ func getProjectAliasForTask(db *DB, taskUID string) (string, error) {
 	}
 
 	if alias == "" {
-
-		return projectUID, nil
+		// If no alias exists, fall back to project name
+		var projectName string
+		err := db.db.QueryRow(`
+			SELECT name FROM projects WHERE project_uid = ?
+		`, projectUID).Scan(&projectName)
+		if err != nil {
+			// If we can't get the name, fall back to UID
+			return projectUID, nil
+		}
+		return projectName, nil
 	}
 
 	return alias, nil


### PR DESCRIPTION
…aliases

Fix bug where projects without aliases were displaying their UID (e.g., "prj_01K8V6M9TPERT9GN1KDTP7AHGY") instead of their name (e.g., "jj-run") in the `tk ls` output.

The getProjectAliasForTask function now:
1. First tries to get the project alias
2. If no alias exists, queries the projects table for the project name
3. Only falls back to the UID if the name query fails

This affects both the table display and JSON output modes when grouping by project.