### PR TITLE
Rename project list command to ls, fix table styling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,41 @@ The `go fmt` tool ensures consistent formatting across all Go code in the monore
 
 ------------------------------------------------------------
 
+## Table Display Library
+
+**All Go code that displays ASCII-style tables must use `github.com/jedib0t/go-pretty/v6/table`.**
+
+The standard table configuration should use:
+- `table.NewWriter()` to create a table
+- `t.SetOutputMirror(os.Stdout)` to output directly to stdout
+- `t.SetStyle(table.StyleLight)` for consistent styling
+- `t.Style().Options.SeparateRows = true` to separate rows
+- `t.Style().Options.DrawBorder = false` to hide outer borders
+- `t.Render()` to render the table
+
+Example:
+```go
+import (
+    "os"
+    "github.com/jedib0t/go-pretty/v6/table"
+)
+
+t := table.NewWriter()
+t.SetOutputMirror(os.Stdout)
+t.AppendHeader(table.Row{"ID", "Status", "Title"})
+
+t.SetStyle(table.StyleLight)
+t.Style().Options.SeparateRows = true
+t.Style().Options.DrawBorder = false
+
+t.AppendRow(table.Row{"1", "done", "Example task"})
+t.Render()
+```
+
+See `tk/display.go` (renderTaskTable function) for a reference implementation.
+
+------------------------------------------------------------
+
 ## Go Style Guide
 
 **All Go code must follow the standards defined in [GO_STYLE_GUIDE.md](./GO_STYLE_GUIDE.md).**

--- a/tk/project_cmd.go
+++ b/tk/project_cmd.go
@@ -3,6 +3,8 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -132,8 +134,8 @@ var projectCreateCmd = &cobra.Command{
 	},
 }
 
-var projectListCmd = &cobra.Command{
-	Use:   "list",
+var projectLsCmd = &cobra.Command{
+	Use:   "ls",
 	Short: "List all projects",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		jsonOutput, _ := cmd.Flags().GetBool("json")
@@ -183,7 +185,7 @@ var projectListCmd = &cobra.Command{
 
 			// Get aliases for this project
 			aliasRows, err := db.db.Query(`
-				SELECT alias FROM project_aliases 
+				SELECT alias FROM project_aliases
 				WHERE project_uid = ? AND node = ?
 			`, projectUID, nodeID)
 			if err != nil {
@@ -224,17 +226,22 @@ var projectListCmd = &cobra.Command{
 			fmt.Println(string(output))
 		} else {
 			t := table.NewWriter()
+			t.SetOutputMirror(os.Stdout)
 			t.AppendHeader(table.Row{"UID", "Name", "Type", "Aliases", "Description", "Created By"})
+
+			t.SetStyle(table.StyleLight)
+			t.Style().Options.SeparateRows = true
+			t.Style().Options.DrawBorder = false
 
 			for _, project := range projects {
 				aliasStr := ""
 				if len(project.Aliases) > 0 {
-					aliasStr = fmt.Sprintf("%v", project.Aliases)
+					aliasStr = strings.Join(project.Aliases, ", ")
 				}
 				t.AppendRow(table.Row{project.UID, project.Name, project.Type, aliasStr, project.Description, project.CreatedBy})
 			}
 
-			fmt.Println(t.Render())
+			t.Render()
 		}
 
 		return nil
@@ -400,8 +407,8 @@ func getNextLamportTimestamp(db *DB) int64 {
 func init() {
 	projectCmd.AddCommand(projectCreateCmd)
 
-	projectListCmd.Flags().Bool("json", false, "Output as JSON")
-	projectCmd.AddCommand(projectListCmd)
+	projectLsCmd.Flags().Bool("json", false, "Output as JSON")
+	projectCmd.AddCommand(projectLsCmd)
 
 	projectCmd.AddCommand(projectAliasCmd)
 


### PR DESCRIPTION


- Renamed projectListCmd to projectLsCmd with 'ls' as the command name
- Updated table rendering to use same machinery as 'tk ls':
  - SetOutputMirror(os.Stdout)
  - StyleLight with SeparateRows=true and DrawBorder=false
  - Render() instead of fmt.Println(t.Render())
- Improved alias display to use strings.Join() instead of fmt.Sprintf("%v", ...)
- Added AGENTS.md rule about using github.com/jedib0t/go-pretty/v6/table for all ASCII-style table displays in Go code