### PR TITLE
Add inner and outer margin settings for booklet printing

### DIFF
--- a/printpdf/cmd/main.go
+++ b/printpdf/cmd/main.go
@@ -23,6 +23,8 @@ var (
 	marginRight    string
 	marginBottom   string
 	marginLeft     string
+	marginInner    string
+	marginOuter    string
 	zoom           int
 	firstPageGuide string
 	keepArtifacts  bool
@@ -60,6 +62,8 @@ func init() {
 	rootCmd.Flags().StringVar(&marginRight, "margin-right", "", "right page margin (overrides the value from --margin when set)")
 	rootCmd.Flags().StringVar(&marginBottom, "margin-bottom", "", "bottom page margin (overrides the value from --margin when set)")
 	rootCmd.Flags().StringVar(&marginLeft, "margin-left", "", "left page margin (overrides the value from --margin when set)")
+	rootCmd.Flags().StringVar(&marginInner, "margin-inner", "", "inner margin for booklet printing (binding side; cannot be used with --margin-left or --margin-right)")
+	rootCmd.Flags().StringVar(&marginOuter, "margin-outer", "", "outer margin for booklet printing (outer edge; cannot be used with --margin-left or --margin-right)")
 	rootCmd.Flags().IntVar(&zoom, "zoom", 100, "zoom percentage for all font sizes (e.g., 80 for 80%, 120 for 120%)")
 	rootCmd.Flags().StringVar(&firstPageGuide, "first-page-guide", "", "draw a thin vertical guide on the first page at the given distance from the left edge (e.g., '3cm')")
 	rootCmd.Flags().BoolVar(&keepArtifacts, "keep-artifacts", false, "keep intermediate artifacts such as HTML and Typst sources next to the output")
@@ -98,6 +102,14 @@ func runConvert(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
+	// Validate margin options: cannot use both left/right and inner/outer
+	hasLeftRight := marginLeft != "" || marginRight != ""
+	hasInnerOuter := marginInner != "" || marginOuter != ""
+	if hasLeftRight && hasInnerOuter {
+		fmt.Fprintf(os.Stderr, "Error: cannot specify both --margin-left/--margin-right and --margin-inner/--margin-outer at the same time\n")
+		os.Exit(1)
+	}
+
 	pageOptions := converter.PageOptions{
 		Columns:        columns,
 		Orientation:    orientation,
@@ -106,6 +118,8 @@ func runConvert(cmd *cobra.Command, args []string) {
 		MarginRight:    marginRight,
 		MarginBottom:   marginBottom,
 		MarginLeft:     marginLeft,
+		MarginInner:    marginInner,
+		MarginOuter:    marginOuter,
 		Zoom:           zoom,
 		FirstPageGuide: strings.TrimSpace(firstPageGuide),
 	}

--- a/printpdf/pkg/converter/converter.go
+++ b/printpdf/pkg/converter/converter.go
@@ -16,13 +16,21 @@ type PageOptions struct {
 	MarginRight       string // Optional right margin override
 	MarginBottom      string // Optional bottom margin override
 	MarginLeft        string // Optional left margin override
+	MarginInner       string // Optional inner margin for booklet printing (binding side)
+	MarginOuter       string // Optional outer margin for booklet printing (outer edge)
 	Zoom              int    // Zoom percentage (e.g., 80 for 80%, 100 is default)
 	FirstPageGuide    string // Optional distance for a vertical guide on the first page (e.g., "3cm")
 	KeepIntermediates bool   // When true, intermediate artifacts (HTML, Typst, etc.) are preserved on disk
 	IntermediateDir   string // Directory where intermediate artifacts should be stored
 }
 
+// isBookletMode returns true if booklet margins (inner/outer) are specified
+func (o PageOptions) isBookletMode() bool {
+	return o.MarginInner != "" || o.MarginOuter != ""
+}
+
 // resolveMargins returns each side's margin along with the default value that was applied.
+// For booklet mode, the inner/outer values are mapped to left/right for :left and :right pages separately.
 func (o PageOptions) resolveMargins() (top, right, bottom, left, uniform string) {
 	uniform = o.Margin
 	if uniform == "" {
@@ -52,6 +60,50 @@ func (o PageOptions) resolveMargins() (top, right, bottom, left, uniform string)
 	return top, right, bottom, left, uniform
 }
 
+// resolveBookletMargins returns the margins for left and right pages in booklet mode
+// Returns (top, outer, bottom, inner, uniform) and (top, inner, bottom, outer, uniform)
+// for :right and :left pages respectively
+func (o PageOptions) resolveBookletMargins() (topRight, outerRight, bottomRight, innerRight, topLeft, innerLeft, bottomLeft, outerLeft, uniform string) {
+	uniform = o.Margin
+	if uniform == "" {
+		uniform = "2cm"
+	}
+
+	top := uniform
+	if o.MarginTop != "" {
+		top = o.MarginTop
+	}
+
+	bottom := uniform
+	if o.MarginBottom != "" {
+		bottom = o.MarginBottom
+	}
+
+	inner := uniform
+	if o.MarginInner != "" {
+		inner = o.MarginInner
+	}
+
+	outer := uniform
+	if o.MarginOuter != "" {
+		outer = o.MarginOuter
+	}
+
+	// Right pages (odd): inner is on left, outer is on right
+	topRight = top
+	outerRight = outer
+	bottomRight = bottom
+	innerRight = inner
+
+	// Left pages (even): inner is on right, outer is on left
+	topLeft = top
+	innerLeft = inner
+	bottomLeft = bottom
+	outerLeft = outer
+
+	return topRight, outerRight, bottomRight, innerRight, topLeft, innerLeft, bottomLeft, outerLeft, uniform
+}
+
 // cssMarginValue returns the CSS margin shorthand that should be applied.
 func (o PageOptions) cssMarginValue() string {
 	top, right, bottom, left, uniform := o.resolveMargins()
@@ -64,6 +116,42 @@ func (o PageOptions) cssMarginValue() string {
 
 // typstMarginValue returns the Typst margin expression.
 func (o PageOptions) typstMarginValue() string {
+	if o.isBookletMode() {
+		// Booklet mode: use inside/outside margins
+		uniform := o.Margin
+		if uniform == "" {
+			uniform = "2cm"
+		}
+
+		top := uniform
+		if o.MarginTop != "" {
+			top = o.MarginTop
+		}
+
+		bottom := uniform
+		if o.MarginBottom != "" {
+			bottom = o.MarginBottom
+		}
+
+		inside := uniform
+		if o.MarginInner != "" {
+			inside = o.MarginInner
+		}
+
+		outside := uniform
+		if o.MarginOuter != "" {
+			outside = o.MarginOuter
+		}
+
+		// Check if all margins are uniform
+		if top == uniform && bottom == uniform && inside == uniform && outside == uniform {
+			return uniform
+		}
+
+		return fmt.Sprintf("(top: %s, outside: %s, bottom: %s, inside: %s)", top, outside, bottom, inside)
+	}
+
+	// Normal mode: use standard left/right margins
 	top, right, bottom, left, uniform := o.resolveMargins()
 	if top == uniform && right == uniform && bottom == uniform && left == uniform {
 		return uniform

--- a/printpdf/pkg/converter/markdown.go
+++ b/printpdf/pkg/converter/markdown.go
@@ -70,12 +70,23 @@ func markdownToHTMLBody(markdown []byte) ([]byte, error) {
 
 // generatePageCSS generates the @page CSS rules based on page options
 func generatePageCSS(options PageOptions) string {
-	margin := options.cssMarginValue()
 	var pageCSS strings.Builder
+	orientation := "portrait"
 	if options.Orientation == "landscape" {
-		fmt.Fprintf(&pageCSS, "@page { size: A4 landscape; margin: %s; }\n", margin)
+		orientation = "landscape"
+	}
+
+	if options.isBookletMode() {
+		// Booklet mode: generate separate rules for :left and :right pages
+		topRight, outerRight, bottomRight, innerRight, topLeft, innerLeft, bottomLeft, outerLeft, _ := options.resolveBookletMargins()
+
+		fmt.Fprintf(&pageCSS, "@page { size: A4 %s; }\n", orientation)
+		fmt.Fprintf(&pageCSS, "@page :right { margin: %s %s %s %s; }\n", topRight, outerRight, bottomRight, innerRight)
+		fmt.Fprintf(&pageCSS, "@page :left { margin: %s %s %s %s; }\n", topLeft, outerLeft, bottomLeft, innerLeft)
 	} else {
-		fmt.Fprintf(&pageCSS, "@page { size: A4 portrait; margin: %s; }\n", margin)
+		// Normal mode: use standard margin
+		margin := options.cssMarginValue()
+		fmt.Fprintf(&pageCSS, "@page { size: A4 %s; margin: %s; }\n", orientation, margin)
 	}
 
 	if guide := strings.TrimSpace(options.FirstPageGuide); guide != "" {

--- a/printpdf/pkg/converter/options_test.go
+++ b/printpdf/pkg/converter/options_test.go
@@ -57,6 +57,32 @@ func TestTypstConverterWithCustomMargin(t *testing.T) {
 			},
 			expectedMargin: "margin: (top: 3cm, right: 1.5cm, bottom: 2.5cm, left: 2cm)",
 		},
+		{
+			name: "booklet margins",
+			options: PageOptions{
+				Columns:     1,
+				Orientation: "portrait",
+				Margin:      "2cm",
+				MarginInner: "3cm",
+				MarginOuter: "1.5cm",
+				Zoom:        100,
+			},
+			expectedMargin: "margin: (top: 2cm, outside: 1.5cm, bottom: 2cm, inside: 3cm)",
+		},
+		{
+			name: "booklet margins with top/bottom",
+			options: PageOptions{
+				Columns:      1,
+				Orientation:  "portrait",
+				Margin:       "2cm",
+				MarginTop:    "3cm",
+				MarginBottom: "2.5cm",
+				MarginInner:  "4cm",
+				MarginOuter:  "1cm",
+				Zoom:         100,
+			},
+			expectedMargin: "margin: (top: 3cm, outside: 1cm, bottom: 2.5cm, inside: 4cm)",
+		},
 	}
 
 	for _, tt := range tests {
@@ -193,6 +219,32 @@ func TestHTMLConverterWithCustomMargin(t *testing.T) {
 				Zoom:         100,
 			},
 			expectedMargin: "margin: 3cm 1.25in 2.5cm 2cm",
+		},
+		{
+			name: "booklet margins",
+			options: PageOptions{
+				Columns:     1,
+				Orientation: "portrait",
+				Margin:      "2cm",
+				MarginInner: "3cm",
+				MarginOuter: "1.5cm",
+				Zoom:        100,
+			},
+			expectedMargin: "@page :right { margin: 2cm 1.5cm 2cm 3cm; }",
+		},
+		{
+			name: "booklet margins with top/bottom",
+			options: PageOptions{
+				Columns:      1,
+				Orientation:  "portrait",
+				Margin:       "2cm",
+				MarginTop:    "3cm",
+				MarginBottom: "2.5cm",
+				MarginInner:  "4cm",
+				MarginOuter:  "1cm",
+				Zoom:         100,
+			},
+			expectedMargin: "@page :right { margin: 3cm 1cm 2.5cm 4cm; }",
 		},
 	}
 


### PR DESCRIPTION
Add support for booklet-style printing with inner/outer margins that automatically adjust for left and right pages:

- Add --margin-inner and --margin-outer CLI flags for booklet printing
- Add validation to prevent using left/right and inner/outer together
- Update CSS generation to use @page :left and :right for booklet mode
- Update Typst generation to use inside/outside margins for booklet mode
- Add comprehensive tests for booklet margin functionality

For booklet printing, inner margins appear on the binding side (left on odd pages, right on even pages), while outer margins appear on the outer edge.