### PR TITLE
tk: Fix inconsistent project identifier handling

### DIFF
--- a/tk/doctor_cmd.go
+++ b/tk/doctor_cmd.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sort"
 
+	"github.com/neongreen/mono/tk/internal/types"
 	"github.com/spf13/cobra"
 )
 
@@ -276,7 +277,7 @@ func getNumberCollisions(db *DB, projectFilter string) ([]DoctorCollision, error
 		}
 		tasksRows.Close()
 
-		alias, err := preferredAliasForProject(db, projectUID)
+		alias, err := preferredAliasForProject(db, types.ProjectUID(projectUID))
 		if err != nil {
 			alias = projectUID
 		}

--- a/tk/id_cmd.go
+++ b/tk/id_cmd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/neongreen/mono/tk/internal/types"
 	"github.com/spf13/cobra"
 )
 
@@ -82,7 +83,7 @@ func describeTask(db *DB, ref string) (*taskIdentity, error) {
 		return nil, fmt.Errorf("failed to load task number for %s: %w", taskUID, err)
 	}
 
-	alias, err := preferredAliasForProject(db, projectUID)
+	alias, err := preferredAliasForProject(db, types.ProjectUID(projectUID))
 	if err != nil {
 		return nil, err
 	}

--- a/tk/internal/types/ids.go
+++ b/tk/internal/types/ids.go
@@ -34,6 +34,21 @@ func (p ProjectUID) Validate() error {
 
 func (p ProjectUID) String() string { return string(p) }
 
+// ProjectRef is an unresolved project reference that could be a ProjectUID, alias, or project name
+type ProjectRef string
+
+// NewProjectRef creates an unresolved project reference from a string
+func NewProjectRef(s string) ProjectRef {
+	return ProjectRef(s)
+}
+
+// IsProjectUID checks if this reference looks like a ProjectUID (starts with "prj_")
+func (r ProjectRef) IsProjectUID() bool {
+	return strings.HasPrefix(string(r), "prj_")
+}
+
+func (r ProjectRef) String() string { return string(r) }
+
 // Alias is a per-node short name for projects
 type Alias string
 

--- a/tk/project_cmd.go
+++ b/tk/project_cmd.go
@@ -257,8 +257,8 @@ var projectAliasCmd = &cobra.Command{
 }
 
 var projectAliasAddCmd = &cobra.Command{
-	Use:   "add <project-uid> <alias>",
-	Short: "Add an alias for a project",
+	Use:   "add <project-ref> <alias>",
+	Short: "Add an alias for a project (project-ref can be a UID, alias, or name)",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		db, err := OpenExistingDB()
@@ -267,7 +267,13 @@ var projectAliasAddCmd = &cobra.Command{
 		}
 		defer db.Close()
 
-		projectUID := args[0]
+		// Resolve the project reference to a ProjectUID
+		projectRef := types.NewProjectRef(args[0])
+		projectUID, err := ResolveProjectRef(db, projectRef)
+		if err != nil {
+			return fmt.Errorf("failed to resolve project: %w", err)
+		}
+
 		alias := args[1]
 
 		// Get current user and node
@@ -283,7 +289,7 @@ var projectAliasAddCmd = &cobra.Command{
 
 		// Create project.alias.add event
 		payload := types.ProjectAliasAddPayload{
-			ProjectUID: projectUID,
+			ProjectUID: projectUID.String(),
 			Alias:      alias,
 			Node:       nodeID,
 			AddedBy:    actor,
@@ -390,8 +396,8 @@ var projectAliasRemoveCmd = &cobra.Command{
 }
 
 var projectRmCmd = &cobra.Command{
-	Use:   "rm <project-uid-or-alias>",
-	Short: "Delete a project",
+	Use:   "rm <project-ref>",
+	Short: "Delete a project (project-ref can be a UID, alias, or name)",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		db, err := OpenExistingDB()
@@ -400,34 +406,11 @@ var projectRmCmd = &cobra.Command{
 		}
 		defer db.Close()
 
-		projectRef := args[0]
-
-		// Try to resolve the project UID from alias or UID
-		var projectUID string
-		nodeID, err := db.GetOrCreateNodeID()
+		// Resolve the project reference to a ProjectUID
+		ref := types.NewProjectRef(args[0])
+		projectUID, err := ResolveProjectRef(db, ref)
 		if err != nil {
-			return err
-		}
-
-		// First try as alias
-		err = db.db.QueryRow(`
-			SELECT project_uid FROM project_aliases 
-			WHERE alias = ? AND node = ?
-		`, projectRef, nodeID).Scan(&projectUID)
-
-		if err != nil {
-			// Try as project UID directly
-			var exists bool
-			err = db.db.QueryRow(`
-				SELECT EXISTS(SELECT 1 FROM projects WHERE project_uid = ?)
-			`, projectRef).Scan(&exists)
-			if err != nil {
-				return fmt.Errorf("failed to query project: %w", err)
-			}
-			if !exists {
-				return fmt.Errorf("project not found: %s", projectRef)
-			}
-			projectUID = projectRef
+			return fmt.Errorf("failed to resolve project: %w", err)
 		}
 
 		// Get current user
@@ -438,7 +421,7 @@ var projectRmCmd = &cobra.Command{
 
 		// Create project.delete event
 		payload := types.ProjectDeletePayload{
-			ProjectUID: projectUID,
+			ProjectUID: projectUID.String(),
 		}
 
 		payloadJSON, err := json.Marshal(payload)

--- a/tk/task_resolver.go
+++ b/tk/task_resolver.go
@@ -114,7 +114,7 @@ func RenderTaskDisplayID(db *DB, taskUID string) (string, error) {
 		return "", fmt.Errorf("failed to load task number for %s: %w", taskUID, err)
 	}
 
-	alias, err := preferredAliasForProject(db, projectUID)
+	alias, err := preferredAliasForProject(db, types.ProjectUID(projectUID))
 	if err != nil {
 		return "", err
 	}
@@ -149,16 +149,23 @@ func RenderTaskDisplayID(db *DB, taskUID string) (string, error) {
 	return fmt.Sprintf("%s-%d-%s", prefix, number, hint), nil
 }
 
-func resolveProjectByAlias(db *DB, alias string) (string, error) {
-	if strings.HasPrefix(alias, "prj_") {
+// ResolveProjectRef resolves an unresolved project reference (UID, alias, or name) to a ProjectUID
+func ResolveProjectRef(db *DB, ref types.ProjectRef) (types.ProjectUID, error) {
+	// If it looks like a ProjectUID, validate and verify it exists
+	if ref.IsProjectUID() {
+		uid := types.ProjectUID(ref)
+		if err := uid.Validate(); err != nil {
+			return "", fmt.Errorf("invalid project UID: %w", err)
+		}
+
 		var count int
-		if err := db.db.QueryRow(`SELECT COUNT(*) FROM projects WHERE project_uid = ?`, alias).Scan(&count); err != nil {
-			return "", fmt.Errorf("failed to lookup project %s: %w", alias, err)
+		if err := db.db.QueryRow(`SELECT COUNT(*) FROM projects WHERE project_uid = ?`, uid).Scan(&count); err != nil {
+			return "", fmt.Errorf("failed to lookup project %s: %w", uid, err)
 		}
 		if count == 0 {
-			return "", fmt.Errorf("project %s not found", alias)
+			return "", fmt.Errorf("project %s not found", uid)
 		}
-		return alias, nil
+		return uid, nil
 	}
 
 	nodeID, err := db.GetOrCreateNodeID()
@@ -173,12 +180,12 @@ func resolveProjectByAlias(db *DB, alias string) (string, error) {
 		WHERE alias = ?
 		ORDER BY CASE WHEN node = ? THEN 0 ELSE 1 END
 		LIMIT 1
-	`, alias, nodeID).Scan(&projectUID)
+	`, ref.String(), nodeID).Scan(&projectUID)
 	if err == nil {
-		return projectUID, nil
+		return types.ProjectUID(projectUID), nil
 	}
 	if err != sql.ErrNoRows {
-		return "", fmt.Errorf("failed to resolve project alias %s: %w", alias, err)
+		return "", fmt.Errorf("failed to resolve project alias %s: %w", ref, err)
 	}
 
 	// If no alias found, try to resolve by project name
@@ -187,17 +194,24 @@ func resolveProjectByAlias(db *DB, alias string) (string, error) {
 		WHERE name = ?
 		ORDER BY created_at
 		LIMIT 1
-	`, alias).Scan(&projectUID)
+	`, ref.String()).Scan(&projectUID)
 	if err == sql.ErrNoRows {
-		return "", fmt.Errorf("project/alias %s not found (checked aliases and project names)", alias)
+		return "", fmt.Errorf("project/alias %s not found (checked aliases and project names)", ref)
 	}
 	if err != nil {
-		return "", fmt.Errorf("failed to resolve project name %s: %w", alias, err)
+		return "", fmt.Errorf("failed to resolve project name %s: %w", ref, err)
 	}
-	return projectUID, nil
+	return types.ProjectUID(projectUID), nil
 }
 
-func preferredAliasForProject(db *DB, projectUID string) (string, error) {
+// resolveProjectByAlias is deprecated - use ResolveProjectRef instead
+// This is kept temporarily for backward compatibility during refactoring
+func resolveProjectByAlias(db *DB, alias string) (string, error) {
+	uid, err := ResolveProjectRef(db, types.NewProjectRef(alias))
+	return string(uid), err
+}
+
+func preferredAliasForProject(db *DB, projectUID types.ProjectUID) (string, error) {
 	nodeID, err := db.GetOrCreateNodeID()
 	if err != nil {
 		return "", err
@@ -209,7 +223,7 @@ func preferredAliasForProject(db *DB, projectUID string) (string, error) {
 		WHERE project_uid = ?
 		ORDER BY CASE WHEN node = ? THEN 0 ELSE 1 END
 		LIMIT 1
-	`, projectUID, nodeID).Scan(&alias)
+	`, projectUID.String(), nodeID).Scan(&alias)
 	if err == sql.ErrNoRows {
 		return "", nil
 	}

--- a/tk/tasks.go
+++ b/tk/tasks.go
@@ -23,7 +23,7 @@ func createTask(db *DB, cmd *cobra.Command, title string) error {
 		return err
 	}
 
-	projectUID, err := resolveProjectByAlias(db, projectFlag)
+	projectUID, err := ResolveProjectRef(db, types.NewProjectRef(projectFlag))
 	if err != nil {
 		return fmt.Errorf("project/alias %q not found. Create it first with: tk project create <name> --alias %s", projectFlag, projectFlag)
 	}
@@ -33,9 +33,9 @@ func createTask(db *DB, cmd *cobra.Command, title string) error {
 	// Compute proposed number (max + 1)
 	var maxNumber int64
 	err = db.db.QueryRow(`
-		SELECT COALESCE(MAX(number), 0) FROM task_numbers 
+		SELECT COALESCE(MAX(number), 0) FROM task_numbers
 		WHERE project_uid = ?
-	`, projectUID).Scan(&maxNumber)
+	`, projectUID.String()).Scan(&maxNumber)
 	if err != nil {
 		return fmt.Errorf("failed to get max number: %w", err)
 	}
@@ -43,7 +43,7 @@ func createTask(db *DB, cmd *cobra.Command, title string) error {
 
 	payload := types.TaskCreatedPayload{
 		TaskUID:        string(taskUID),
-		ProjectUID:     projectUID,
+		ProjectUID:     projectUID.String(),
 		ProposedNumber: proposedNumber,
 		CreatedNode:    nodeID,
 		Title:          title,
@@ -75,7 +75,7 @@ func createTask(db *DB, cmd *cobra.Command, title string) error {
 
 	numberPayload := types.TaskNumberSetPayload{
 		TaskUID:    string(taskUID),
-		ProjectUID: projectUID,
+		ProjectUID: projectUID.String(),
 		Number:     proposedNumber,
 		Reason:     "initial",
 	}
@@ -102,7 +102,24 @@ func createTask(db *DB, cmd *cobra.Command, title string) error {
 		return fmt.Errorf("failed to project task number: %w", err)
 	}
 
-	displayID := fmt.Sprintf("%s-%d", projectFlag, proposedNumber)
+	// Get a friendly display name (preferred alias, or project name, or UID as fallback)
+	displayPrefix, err := preferredAliasForProject(db, projectUID)
+	if err != nil {
+		return fmt.Errorf("failed to get display prefix: %w", err)
+	}
+	if displayPrefix == "" {
+		// No alias found, try to get project name
+		var projectName string
+		err = db.db.QueryRow(`SELECT name FROM projects WHERE project_uid = ?`, projectUID.String()).Scan(&projectName)
+		if err == nil && projectName != "" {
+			displayPrefix = projectName
+		} else {
+			// Fallback to UID
+			displayPrefix = projectUID.String()
+		}
+	}
+
+	displayID := fmt.Sprintf("%s-%d", displayPrefix, proposedNumber)
 	fmt.Printf("Created task %s: %s\n", displayID, title)
 	return nil
 }

--- a/tk/utils.go
+++ b/tk/utils.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os/user"
 	"strings"
+
+	"github.com/neongreen/mono/tk/internal/types"
 )
 
 // extractPrefix extracts the prefix from a TaskID (format: prefix-number-node)
@@ -26,7 +28,7 @@ func getProjectAliasForTask(db *DB, taskUID string) (string, error) {
 		return "", fmt.Errorf("failed to get project for task %s: %w", taskUID, err)
 	}
 
-	alias, err := preferredAliasForProject(db, projectUID)
+	alias, err := preferredAliasForProject(db, types.ProjectUID(projectUID))
 	if err != nil {
 		return "", err
 	}
@@ -93,7 +95,7 @@ func getAllProjectDisplayNames(db *DB) (map[string]string, error) {
 		}
 
 		// Try to get preferred alias
-		alias, err := preferredAliasForProject(db, projectUID)
+		alias, err := preferredAliasForProject(db, types.ProjectUID(projectUID))
 		if err != nil {
 			// On error, fall back to name
 			result[projectUID] = name


### PR DESCRIPTION
This commit introduces a newtype pattern in Go to prevent bugs related to project reference resolution. Previously, projects could be referenced by UID, alias, or name, but these were all handled as strings, leading to inconsistent behavior and potential bugs.

Changes:
- Add ProjectRef type for unresolved project references (UID, alias, or name)
- Add ResolveProjectRef() function that takes ProjectRef and returns ProjectUID
- Update preferredAliasForProject() to take ProjectUID instead of string
- Fix project alias add command to resolve any project reference
- Fix project rm command to use standard resolution logic
- Fix task creation to display friendly alias instead of raw UID
- Update all call sites to use strongly-typed functions

This follows the Haskell-style newtype pattern to make invalid states unrepresentable at compile time. Functions that need a resolved ProjectUID now explicitly take that type, while functions that accept user input take ProjectRef and resolve internally.