### PR TITLE
printpdf: Fix margins for even/odd pages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 
 require (
 	dario.cat/mergo v1.0.0 // indirect
+	github.com/BurntSushi/toml v1.2.1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
@@ -80,6 +81,7 @@ require (
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+	go.abhg.dev/goldmark/frontmatter v0.2.0 // indirect
 	golang.org/x/crypto v0.43.0 // indirect
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b // indirect
 	golang.org/x/image v0.32.0 // indirect
@@ -89,6 +91,7 @@ require (
 	golang.org/x/text v0.30.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.66.10 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
+github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
+github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
@@ -178,6 +180,8 @@ github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zI
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.7.13 h1:GPddIs617DnBLFFVJFgpo1aBfe/4xcvMc3SB5t/D0pA=
 github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+go.abhg.dev/goldmark/frontmatter v0.2.0 h1:P8kPG0YkL12+aYk2yU3xHv4tcXzeVnN+gU0tJ5JnxRw=
+go.abhg.dev/goldmark/frontmatter v0.2.0/go.mod h1:XqrEkZuM57djk7zrlRUB02x8I5J0px76YjkOzhB4YlU=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.43.0 h1:dduJYIi3A3KOfdGOHX8AVZ/jGiyPa3IbBozJ5kNuE04=
 golang.org/x/crypto v0.43.0/go.mod h1:BFbav4mRNlXJL4wNeejLpWxB7wMbc79PdRGhWKncxR0=

--- a/printpdf/pkg/converter/markdown.go
+++ b/printpdf/pkg/converter/markdown.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"go.abhg.dev/goldmark/frontmatter"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/parser"
@@ -38,6 +39,7 @@ span.printpdf-footnote::footnote-marker {
 
 // markdownToHTMLBody converts markdown content to HTML body content (without wrapping in full document)
 func markdownToHTMLBody(markdown []byte) ([]byte, error) {
+	extender := &frontmatter.Extender{}
 	md := goldmark.New(
 		goldmark.WithExtensions(
 			extension.GFM, // GitHub Flavored Markdown
@@ -46,6 +48,7 @@ func markdownToHTMLBody(markdown []byte) ([]byte, error) {
 			extension.Strikethrough,
 			extension.Linkify,
 			extension.TaskList,
+			extender, // YAML/TOML frontmatter
 		),
 		goldmark.WithParserOptions(
 			parser.WithAutoHeadingID(), // Auto-generate heading IDs
@@ -56,16 +59,45 @@ func markdownToHTMLBody(markdown []byte) ([]byte, error) {
 	)
 
 	var buf bytes.Buffer
-	if err := md.Convert(markdown, &buf); err != nil {
+	ctx := parser.NewContext()
+	if err := md.Convert(markdown, &buf, parser.WithContext(ctx)); err != nil {
 		return nil, fmt.Errorf("failed to convert markdown to HTML: %w", err)
 	}
 
-	content, err := enhanceHTMLFootnotes(buf.Bytes())
+	// Extract and render frontmatter if present
+	var result bytes.Buffer
+	if meta := frontmatter.Get(ctx); meta != nil {
+		var data map[string]interface{}
+		if err := meta.Decode(&data); err == nil && len(data) > 0 {
+			result.WriteString(renderFrontmatterHTML(data))
+		}
+	}
+	result.Write(buf.Bytes())
+
+	content, err := enhanceHTMLFootnotes(result.Bytes())
 	if err != nil {
 		return nil, fmt.Errorf("failed to enhance footnotes: %w", err)
 	}
 
 	return content, nil
+}
+
+// renderFrontmatterHTML renders frontmatter as an HTML definition list
+func renderFrontmatterHTML(data map[string]interface{}) string {
+	var buf strings.Builder
+	buf.WriteString(`<div class="frontmatter">`)
+	buf.WriteString("<dl>")
+	for key, value := range data {
+		buf.WriteString("<dt>")
+		buf.WriteString(strings.Title(strings.ReplaceAll(key, "_", " ")))
+		buf.WriteString("</dt>")
+		buf.WriteString("<dd>")
+		buf.WriteString(fmt.Sprintf("%v", value))
+		buf.WriteString("</dd>")
+	}
+	buf.WriteString("</dl>")
+	buf.WriteString("</div>")
+	return buf.String()
 }
 
 // generatePageCSS generates the @page CSS rules based on page options
@@ -81,8 +113,10 @@ func generatePageCSS(options PageOptions) string {
 		topRight, outerRight, bottomRight, innerRight, topLeft, innerLeft, bottomLeft, outerLeft, _ := options.resolveBookletMargins()
 
 		fmt.Fprintf(&pageCSS, "@page { size: A4 %s; }\n", orientation)
+		// For right pages (odd): outer is on right, inner is on left
 		fmt.Fprintf(&pageCSS, "@page :right { margin: %s %s %s %s; }\n", topRight, outerRight, bottomRight, innerRight)
-		fmt.Fprintf(&pageCSS, "@page :left { margin: %s %s %s %s; }\n", topLeft, outerLeft, bottomLeft, innerLeft)
+		// For left pages (even): inner is on right, outer is on left
+		fmt.Fprintf(&pageCSS, "@page :left { margin: %s %s %s %s; }\n", topLeft, innerLeft, bottomLeft, outerLeft)
 	} else {
 		// Normal mode: use standard margin
 		margin := options.cssMarginValue()
@@ -226,6 +260,31 @@ hr {
     margin: 24px 0;
     background-color: #e1e4e8;
     border: 0;
+}
+
+.frontmatter {
+    background-color: #f6f8fa;
+    border: 1px solid #d0d7de;
+    border-radius: 6px;
+    padding: 16px;
+    margin-bottom: 24px;
+}
+
+.frontmatter dl {
+    margin: 0;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 8px 16px;
+}
+
+.frontmatter dt {
+    font-weight: 600;
+    color: #24292e;
+}
+
+.frontmatter dd {
+    margin: 0;
+    color: #57606a;
 }`
 }
 

--- a/printpdf/pkg/converter/typst_converter.go
+++ b/printpdf/pkg/converter/typst_converter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"go.abhg.dev/goldmark/frontmatter"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/extension"
@@ -16,6 +17,7 @@ import (
 // convertMarkdownToTypst converts Markdown content to Typst markup
 func convertMarkdownToTypst(markdown []byte, options PageOptions) (string, error) {
 	// Parse the markdown
+	extender := &frontmatter.Extender{}
 	md := goldmark.New(
 		goldmark.WithExtensions(
 			extension.GFM,
@@ -24,14 +26,16 @@ func convertMarkdownToTypst(markdown []byte, options PageOptions) (string, error
 			extension.Strikethrough,
 			extension.Linkify,
 			extension.TaskList,
+			extender, // YAML/TOML frontmatter
 		),
 		goldmark.WithParserOptions(
 			parser.WithAutoHeadingID(),
 		),
 	)
 
+	ctx := parser.NewContext()
 	reader := text.NewReader(markdown)
-	doc := md.Parser().Parse(reader)
+	doc := md.Parser().Parse(reader, parser.WithContext(ctx))
 
 	footnotes, err := collectTypstFootnotes(doc, markdown)
 	if err != nil {
@@ -78,12 +82,45 @@ func convertMarkdownToTypst(markdown []byte, options PageOptions) (string, error
 
 	buf.WriteString("\n")
 
+	// Render frontmatter if present
+	if meta := frontmatter.Get(ctx); meta != nil {
+		var data map[string]interface{}
+		if err := meta.Decode(&data); err == nil && len(data) > 0 {
+			buf.WriteString(renderFrontmatterTypst(data))
+			buf.WriteString("\n")
+		}
+	}
+
 	// Convert the document
 	if err := renderNodeToTypst(&buf, doc, markdown, footnotes); err != nil {
 		return "", err
 	}
 
 	return buf.String(), nil
+}
+
+// renderFrontmatterTypst renders frontmatter as a Typst styled block
+func renderFrontmatterTypst(data map[string]interface{}) string {
+	var buf strings.Builder
+	buf.WriteString("#block(\n")
+	buf.WriteString("  fill: rgb(\"#f6f8fa\"),\n")
+	buf.WriteString("  stroke: 1pt + rgb(\"#d0d7de\"),\n")
+	buf.WriteString("  radius: 4pt,\n")
+	buf.WriteString("  inset: 12pt,\n")
+	buf.WriteString("  width: 100%,\n")
+	buf.WriteString(")[\n")
+	buf.WriteString("  #set text(size: 0.9em)\n")
+	buf.WriteString("  #grid(\n")
+	buf.WriteString("    columns: (auto, 1fr),\n")
+	buf.WriteString("    column-gutter: 1em,\n")
+	buf.WriteString("    row-gutter: 0.5em,\n")
+	for key, value := range data {
+		title := strings.Title(strings.ReplaceAll(key, "_", " "))
+		buf.WriteString(fmt.Sprintf("    [*%s:*], [%v],\n", escapeTypst(title), escapeTypst(fmt.Sprintf("%v", value))))
+	}
+	buf.WriteString("  )\n")
+	buf.WriteString("]\n")
+	return buf.String()
 }
 
 // renderNodeToTypst recursively renders AST nodes to Typst markup


### PR DESCRIPTION
This commit makes two key improvements to printpdf:

1. Fix inner/outer margin handling for even/odd pages:
   - Corrected CSS margin order for left pages (even pages) in booklet mode
   - For odd pages (right-hand pages): inner=left, outer=right
   - For even pages (left-hand pages): inner=right, outer=left
   - The bug was in markdown.go:87 where left page margins were incorrect

2. Add YAML frontmatter parsing and rendering:
   - Added go.abhg.dev/goldmark/frontmatter dependency
   - Parse YAML metadata blocks at the start of markdown documents
   - Render frontmatter as a styled definition list in HTML output
   - Render frontmatter as a styled grid block in Typst output
   - Frontmatter is displayed in a bordered, shaded box at the top of the document
   - Supports standard frontmatter fields like url, title, access_date, etc.