### PR TITLE
Remove duplicate GitHub release fetching code from prrun

### DIFF
--- a/prrun/github.go
+++ b/prrun/github.go
@@ -35,71 +35,20 @@ func parsePRURL(prURL string) (*PRInfo, error) {
 	return &PRInfo{Owner: matches[1], Repo: matches[2], PRNum: prNum}, nil
 }
 
-// fetchAllReleases fetches all releases from GitHub API with pagination support
-func fetchAllReleases(owner, repo string) ([]GitHubRelease, error) {
-	var allReleases []GitHubRelease
-	page := 1
-	perPage := 100 // Max allowed by GitHub API
-
-	for {
-		apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases?per_page=%d&page=%d",
-			owner, repo, perPage, page)
-
-		debugLog("Fetching releases page %d from: %s", page, apiURL)
-
-		req, err := ghrelease.CreateAuthenticatedRequest("GET", apiURL)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create request: %w", err)
-		}
-
-		client := &http.Client{}
-		resp, err := client.Do(req)
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch releases: %w", err)
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
-		}
-
-		var releases []GitHubRelease
-		if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
-			return nil, fmt.Errorf("failed to decode releases: %w", err)
-		}
-
-		debugLog("Found %d releases on page %d", len(releases), page)
-
-		if len(releases) == 0 {
-			break
-		}
-
-		allReleases = append(allReleases, releases...)
-
-		// If we got fewer releases than requested, we've reached the end
-		if len(releases) < perPage {
-			break
-		}
-
-		page++
-	}
-
-	debugLog("Total releases fetched: %d", len(allReleases))
-	return allReleases, nil
-}
-
 func findPRRelease(owner, repo string,
 	prNum int, project string,
-) (*GitHubRelease, error) {
+) (*ghrelease.Release, error) {
 	debugLog("Looking for PR #%d in %s/%s (project: %s)", prNum, owner, repo, project)
 
-	releases, err := fetchAllReleases(owner, repo)
+	releases, err := ghrelease.ListReleases(owner, repo)
 	if err != nil {
 		return nil, err
 	}
 
+	debugLog("Total releases fetched: %d", len(releases))
+
 	prPattern := fmt.Sprintf("pr-%d.", prNum)
-	var matchingReleases []GitHubRelease
+	var matchingReleases []ghrelease.Release
 	for _, release := range releases {
 		tagName := release.TagName
 		if project != "" {
@@ -124,23 +73,8 @@ func findPRRelease(owner, repo string,
 	return &matchingReleases[0], nil
 }
 
-func getPlatformBinaryName(release *GitHubRelease, projectName string) (string, string, error) {
-	// Convert GitHubRelease to ghrelease.Release
-	ghrRelease := &ghrelease.Release{
-		TagName:    release.TagName,
-		Name:       release.Name,
-		Prerelease: release.Prerelease,
-		Assets:     make([]ghrelease.Asset, len(release.Assets)),
-	}
-	for i, asset := range release.Assets {
-		ghrRelease.Assets[i] = ghrelease.Asset{
-			Name:               asset.Name,
-			URL:                asset.URL,
-			BrowserDownloadURL: asset.BrowserDownloadURL,
-		}
-	}
-
-	asset, err := ghrelease.FindPlatformAsset(ghrRelease, projectName)
+func getPlatformBinaryName(release *ghrelease.Release, projectName string) (string, string, error) {
+	asset, err := ghrelease.FindPlatformAsset(release, projectName)
 	if err != nil {
 		return "", "", err
 	}
@@ -149,17 +83,19 @@ func getPlatformBinaryName(release *GitHubRelease, projectName string) (string, 
 }
 
 // findAllPRReleases finds all releases for a given PR number
-func findAllPRReleases(owner, repo string, prNum int) ([]GitHubRelease, error) {
+func findAllPRReleases(owner, repo string, prNum int) ([]ghrelease.Release, error) {
 	debugLog("Looking for all releases for PR #%d in %s/%s", prNum, owner, repo)
 
-	releases, err := fetchAllReleases(owner, repo)
+	releases, err := ghrelease.ListReleases(owner, repo)
 	if err != nil {
 		return nil, err
 	}
 
+	debugLog("Total releases fetched: %d", len(releases))
+
 	// Find all releases for this PR
 	prPattern := fmt.Sprintf("pr-%d.", prNum)
-	var matchingReleases []GitHubRelease
+	var matchingReleases []ghrelease.Release
 	for _, release := range releases {
 		if strings.Contains(release.TagName, prPattern) {
 			debugLog("Found matching release: %s (prerelease=%v)", release.TagName, release.Prerelease)
@@ -183,7 +119,7 @@ func extractProjectFromTag(tag string) string {
 }
 
 // extractUniqueProjects extracts unique project names from a list of releases
-func extractUniqueProjects(releases []GitHubRelease) []string {
+func extractUniqueProjects(releases []ghrelease.Release) []string {
 	projectSet := make(map[string]bool)
 	var uniqueProjects []string
 	for _, r := range releases {

--- a/prrun/github_test.go
+++ b/prrun/github_test.go
@@ -4,19 +4,20 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/neongreen/mono/lib/ghrelease"
 )
 
 func TestGetPlatformBinaryName(t *testing.T) {
-	release := &GitHubRelease{TagName: "dissect--pr-123.1", Assets: []struct {
-		Name               string `json:"name"`
-		URL                string `json:"url"`
-		BrowserDownloadURL string `json:"browser_download_url"`
-	}{
-		{Name: "dissect-pr-123.1-linux-amd64", URL: "https://api.github.com/repos/example/repo/releases/assets/123", BrowserDownloadURL: "https://github.com/example/repo/releases/download/dissect--pr-123.1/dissect-pr-123.1-linux-amd64"},
-		{Name: "dissect-pr-123.1-linux-arm64", URL: "https://api.github.com/repos/example/repo/releases/assets/124", BrowserDownloadURL: "https://github.com/example/repo/releases/download/dissect--pr-123.1/dissect-pr-123.1-linux-arm64"},
-		{Name: "dissect-pr-123.1-darwin-arm64", URL: "https://api.github.com/repos/example/repo/releases/assets/125", BrowserDownloadURL: "https://github.com/example/repo/releases/download/dissect--pr-123.1/dissect-pr-123.1-darwin-arm64"},
-		{Name: "dissect-pr-123.1-darwin-amd64", URL: "https://api.github.com/repos/example/repo/releases/assets/126", BrowserDownloadURL: "https://github.com/example/repo/releases/download/dissect--pr-123.1/dissect-pr-123.1-darwin-amd64"},
-	}}
+	release := &ghrelease.Release{
+		TagName: "dissect--pr-123.1",
+		Assets: []ghrelease.Asset{
+			{Name: "dissect-pr-123.1-linux-amd64", URL: "https://api.github.com/repos/example/repo/releases/assets/123", BrowserDownloadURL: "https://github.com/example/repo/releases/download/dissect--pr-123.1/dissect-pr-123.1-linux-amd64"},
+			{Name: "dissect-pr-123.1-linux-arm64", URL: "https://api.github.com/repos/example/repo/releases/assets/124", BrowserDownloadURL: "https://github.com/example/repo/releases/download/dissect--pr-123.1/dissect-pr-123.1-linux-arm64"},
+			{Name: "dissect-pr-123.1-darwin-arm64", URL: "https://api.github.com/repos/example/repo/releases/assets/125", BrowserDownloadURL: "https://github.com/example/repo/releases/download/dissect--pr-123.1/dissect-pr-123.1-darwin-arm64"},
+			{Name: "dissect-pr-123.1-darwin-amd64", URL: "https://api.github.com/repos/example/repo/releases/assets/126", BrowserDownloadURL: "https://github.com/example/repo/releases/download/dissect--pr-123.1/dissect-pr-123.1-darwin-amd64"},
+		},
+	}
 	binaryName, downloadURL, err := getPlatformBinaryName(release, "dissect")
 	if err != nil {
 		t.Fatalf("getPlatformBinaryName() error = %v", err)
@@ -32,13 +33,9 @@ func TestGetPlatformBinaryName(t *testing.T) {
 }
 
 func TestGetPlatformBinaryName_NoAssets(t *testing.T) {
-	release := &GitHubRelease{
+	release := &ghrelease.Release{
 		TagName: "test--pr-1.1",
-		Assets: []struct {
-			Name               string `json:"name"`
-			URL                string `json:"url"`
-			BrowserDownloadURL string `json:"browser_download_url"`
-		}{},
+		Assets:  []ghrelease.Asset{},
 	}
 	_, _, err := getPlatformBinaryName(release, "test")
 	if err == nil {
@@ -52,16 +49,15 @@ func TestGetPlatformBinaryName_NoAssets(t *testing.T) {
 }
 
 func TestGetPlatformBinaryName_DoubleDashFormat(t *testing.T) {
-	release := &GitHubRelease{TagName: "dissect--pr-123.1", Assets: []struct {
-		Name               string `json:"name"`
-		URL                string `json:"url"`
-		BrowserDownloadURL string `json:"browser_download_url"`
-	}{
-		{Name: "dissect--pr-123.1-linux-amd64", URL: "https://api.github.com/repos/example/repo/releases/assets/127", BrowserDownloadURL: "https://github.com/example/repo/releases/download/dissect--pr-123.1/dissect--pr-123.1-linux-amd64"},
-		{Name: "dissect--pr-123.1-linux-arm64", URL: "https://api.github.com/repos/example/repo/releases/assets/128", BrowserDownloadURL: "https://github.com/example/repo/releases/download/dissect--pr-123.1/dissect--pr-123.1-linux-arm64"},
-		{Name: "dissect--pr-123.1-darwin-arm64", URL: "https://api.github.com/repos/example/repo/releases/assets/129", BrowserDownloadURL: "https://github.com/example/repo/releases/download/dissect--pr-123.1/dissect--pr-123.1-darwin-arm64"},
-		{Name: "dissect--pr-123.1-darwin-amd64", URL: "https://api.github.com/repos/example/repo/releases/assets/130", BrowserDownloadURL: "https://github.com/example/repo/releases/download/dissect--pr-123.1/dissect--pr-123.1-darwin-amd64"},
-	}}
+	release := &ghrelease.Release{
+		TagName: "dissect--pr-123.1",
+		Assets: []ghrelease.Asset{
+			{Name: "dissect--pr-123.1-linux-amd64", URL: "https://api.github.com/repos/example/repo/releases/assets/127", BrowserDownloadURL: "https://github.com/example/repo/releases/download/dissect--pr-123.1/dissect--pr-123.1-linux-amd64"},
+			{Name: "dissect--pr-123.1-linux-arm64", URL: "https://api.github.com/repos/example/repo/releases/assets/128", BrowserDownloadURL: "https://github.com/example/repo/releases/download/dissect--pr-123.1/dissect--pr-123.1-linux-arm64"},
+			{Name: "dissect--pr-123.1-darwin-arm64", URL: "https://api.github.com/repos/example/repo/releases/assets/129", BrowserDownloadURL: "https://github.com/example/repo/releases/download/dissect--pr-123.1/dissect--pr-123.1-darwin-arm64"},
+			{Name: "dissect--pr-123.1-darwin-amd64", URL: "https://api.github.com/repos/example/repo/releases/assets/130", BrowserDownloadURL: "https://github.com/example/repo/releases/download/dissect--pr-123.1/dissect--pr-123.1-darwin-amd64"},
+		},
+	}
 	binaryName, downloadURL, err := getPlatformBinaryName(release, "dissect")
 	if err != nil {
 		t.Fatalf("getPlatformBinaryName() should handle double dash format, error = %v",

--- a/prrun/main.go
+++ b/prrun/main.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/neongreen/mono/lib/ghrelease"
 )
 
 func main() {
@@ -73,7 +75,7 @@ func main() {
 	// Only show debug info on errors, not on success
 
 	// Find the PR release (or all releases if no project specified)
-	var release *GitHubRelease
+	var release *ghrelease.Release
 	if projectName != "" {
 		// Project explicitly specified
 		release, err = findPRRelease(prInfo.Owner, prInfo.Repo, prInfo.PRNum, projectName)

--- a/prrun/main_test.go
+++ b/prrun/main_test.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/neongreen/mono/lib/ghrelease"
 )
 
 func TestExtractProjectFromTag(t *testing.T) {
@@ -58,12 +60,12 @@ func TestFindAllPRReleases(t *testing.T) {
 func TestExtractUniqueProjects(t *testing.T) {
 	tests := []struct {
 		name     string
-		releases []GitHubRelease
+		releases []ghrelease.Release
 		want     []string
 	}{
 		{
 			name: "single project with multiple versions",
-			releases: []GitHubRelease{
+			releases: []ghrelease.Release{
 				{TagName: "printpdf--pr-54.1"},
 				{TagName: "printpdf--pr-54.2"},
 				{TagName: "printpdf--pr-54.3"},
@@ -72,7 +74,7 @@ func TestExtractUniqueProjects(t *testing.T) {
 		},
 		{
 			name: "multiple different projects",
-			releases: []GitHubRelease{
+			releases: []ghrelease.Release{
 				{TagName: "dissect--pr-123.1"},
 				{TagName: "markdown-format--pr-123.1"},
 			},
@@ -80,7 +82,7 @@ func TestExtractUniqueProjects(t *testing.T) {
 		},
 		{
 			name: "multiple projects with multiple versions each",
-			releases: []GitHubRelease{
+			releases: []ghrelease.Release{
 				{TagName: "dissect--pr-123.1"},
 				{TagName: "dissect--pr-123.2"},
 				{TagName: "markdown-format--pr-123.1"},
@@ -90,12 +92,12 @@ func TestExtractUniqueProjects(t *testing.T) {
 		},
 		{
 			name:     "empty releases list",
-			releases: []GitHubRelease{},
+			releases: []ghrelease.Release{},
 			want:     []string{},
 		},
 		{
 			name: "single release",
-			releases: []GitHubRelease{
+			releases: []ghrelease.Release{
 				{TagName: "dissect--pr-1.1"},
 			},
 			want: []string{"dissect"},

--- a/prrun/types.go
+++ b/prrun/types.go
@@ -1,21 +1,5 @@
 package main
 
-// GitHubRelease represents a GitHub release
-type GitHubRelease struct {
-	TagName    string `json:"tag_name"`
-	Name       string `json:"name"`
-	Prerelease bool   `json:"prerelease"`
-	Assets     []struct {
-		Name string `json:"name"`
-		// URL is the GitHub API URL for the asset (e.g., https://api.github.com/repos/.../assets/123)
-		// This URL works with authentication and is REQUIRED for private releases
-		URL string `json:"url"`
-		// BrowserDownloadURL is the direct download URL (e.g., https://github.com/.../releases/download/...)
-		// This URL does NOT work for private releases - only use URL field
-		BrowserDownloadURL string `json:"browser_download_url"`
-	} `json:"assets"`
-}
-
 // PRInfo contains parsed PR information
 type PRInfo struct {
 	Owner   string


### PR DESCRIPTION
The fetchAllReleases() function in prrun/github.go was an exact
duplicate of lib/ghrelease.ListReleases(). This change:

- Removes fetchAllReleases() from prrun (52 lines)
- Replaces GitHubRelease type with ghrelease.Release throughout prrun
- Updates all functions to use ghrelease.ListReleases() instead
- Simplifies getPlatformBinaryName() by removing conversion logic
- Updates all tests to use ghrelease.Release type

This eliminates ~50 lines of duplicated pagination logic and ensures
consistent GitHub API interaction across the codebase.