### PR TITLE
Add depguard linter to prohibit 'flag' package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,8 +13,17 @@ linters:
   - govet
   - errorlint
   - ineffassign
+  - depguard
   # - nilerr  # Routinely flags graceful degradation patterns as bugs (e.g., fallback to UID when name lookup fails)
   settings:
+    depguard:
+      rules:
+        prevent-flag-package:
+          files:
+            - "$all"
+          deny:
+            - pkg: "flag"
+              desc: "use github.com/spf13/cobra instead of the flag package"
     staticcheck:
       checks:
       - all


### PR DESCRIPTION
Enable the depguard linter in golangci-lint configuration to prevent
use of the standard library 'flag' package and require use of
github.com/spf13/cobra instead for CLI argument parsing.

The linter will catch any imports of "flag" and suggest using cobra,
ensuring consistency across the codebase for command-line interfaces.