### PR TITLE
Fix release workflow to use actual branch instead of hardcoded 'main'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,9 +96,11 @@ jobs:
         run: |
           PROJECT="${MATRIX_PROJECT}"
 
-          # For main branch releases
-          REF="main"
-          REF_SAFE="main"
+          # Extract branch name from github.ref (e.g., refs/heads/main -> main)
+          REF="${GITHUB_REF#refs/heads/}"
+
+          # Create safe version for tags (replace / with -)
+          REF_SAFE="${REF//\//-}"
 
           # Find existing tags for this project+ref combination
           TAG_PREFIX="${PROJECT}--${REF_SAFE}."
@@ -128,6 +130,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
           echo "Building ${PROJECT} version ${VERSION} (tag: ${TAG})"
+          echo "Branch: ${REF} (safe: ${REF_SAFE})"
         env:
           MATRIX_PROJECT: ${{ matrix.project }}
 
@@ -162,7 +165,7 @@ jobs:
           body: |
             Release of **${{ matrix.project }}** version `${{ steps.version.outputs.version }}`
 
-            Built from: main branch
+            Built from: `${{ steps.version.outputs.ref }}` branch
             Commit: ${{ github.sha }}
 
             ## Installation


### PR DESCRIPTION
The version determination step was hardcoded to always use "main" as the branch reference, regardless of which branch triggered the workflow. This caused releases from feature branches to be incorrectly labeled as "main" releases.

Changes:
- Extract actual branch name from GITHUB_REF instead of hardcoding
- Create safe version for tags by replacing '/' with '-'
- Update release body to show actual branch instead of "main"
- Add debug output showing both original and safe branch names

Example:
- Branch: claude/jj-run-parallel-workers-011CV631VKGBt3UoeKutCR5o
- Safe: claude-jj-run-parallel-workers-011CV631VKGBt3UoeKutCR5o
- Tag: jj-run--claude-jj-run-parallel-workers-011CV631VKGBt3UoeKutCR5o.1

Verified with:
- actionlint (passed)
- pinact run --verify (passed)