### PR TITLE
Add Stop hook to compile Go code before stopping (web-only)

### DIFF
--- a/.claude/hooks/go-compile-check.sh
+++ b/.claude/hooks/go-compile-check.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Hook to compile all Go code and tests on Stop
+# Only runs in Claude Code web environment
+
+# Only run in Claude Code web (remote environment)
+# CLAUDE_CODE_REMOTE=true means we're in the web version
+if [ "$CLAUDE_CODE_REMOTE" != "true" ]; then
+  # Running in local Claude Code CLI - skip this check
+  exit 0
+fi
+
+echo "Checking Go compilation..." >&2
+
+# Find all Go modules in the repository
+cd "$CLAUDE_PROJECT_DIR" || exit 1
+
+# Try to build all Go packages
+if ! go build ./...; then
+  echo "ERROR: Go compilation failed. Fix compilation errors before stopping." >&2
+  exit 2
+fi
+
+# Try to build all Go tests
+if ! go test -c ./... -o /dev/null; then
+  echo "ERROR: Go test compilation failed. Fix test compilation errors before stopping." >&2
+  exit 2
+fi
+
+echo "Go compilation check passed!" >&2
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,6 +25,17 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "matcher": "stop",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/go-compile-check.sh"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
This hook runs on Stop in Claude Code web and checks that all Go code
and tests compile successfully. If compilation fails, the Stop action
is declined with exit code 2.

The hook only runs when CLAUDE_CODE_REMOTE=true (web environment) and
skips in local Claude Code CLI to avoid disrupting local development.

Changes:
- Add .claude/hooks/go-compile-check.sh script
- Register Stop hook in .claude/settings.json