### PR TITLE
Fix Go module downloads in remote environment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,3 +18,27 @@ There are two versions:
 **Important:** `tk-dev` Just Works™ - you don't need to run `go build` or anything. Just use `tk-dev` directly as a command, and it will build from source if needed.
 
 When working on `tk` itself, use `tk-dev` to test your changes. Use `tk` for normal task tracking.
+
+## Remote environment (Claude Code on the web)
+
+### Go builds and dependencies
+
+The remote environment has internet access through an HTTP proxy. However, there's a networking quirk that affects Go module downloads:
+
+**The issue:** `storage.googleapis.com` (where Go stores module zip files) is in the `no_proxy` environment variable. This prevents Go from using the HTTP proxy for DNS resolution, causing failures like:
+```
+dial tcp: lookup storage.googleapis.com on 8.8.8.8:53: i/o timeout
+```
+
+**The fix:** The SessionStart hook (`scripts/install-mise-remote.sh`) automatically unsets `no_proxy` and `NO_PROXY` environment variables. This allows Go to use the HTTP proxy for all connections, including DNS resolution.
+
+**What this means:**
+- `go build`, `go mod download`, etc. work without any special configuration
+- All Go commands automatically use the proxy
+- Direct DNS queries (UDP port 53) don't work, but proxy-based resolution does
+- This fix is applied automatically when you start a new Claude Code session
+
+If you encounter Go build issues in the remote environment, verify that `no_proxy` is unset:
+```bash
+env | grep -i no_proxy  # Should return nothing
+```

--- a/scripts/install-mise-remote.sh
+++ b/scripts/install-mise-remote.sh
@@ -19,6 +19,16 @@ fi
 # Download and install mise
 curl https://mise.jdx.dev/install.sh | sh
 
+# Fix Go module downloads by removing no_proxy restrictions
+# The environment has an HTTP proxy that handles DNS, but *.googleapis.com in no_proxy
+# prevents Go from using it, causing DNS resolution failures.
+if [ -n "$CLAUDE_ENV_FILE" ]; then
+  echo 'unset no_proxy' >> "$CLAUDE_ENV_FILE"
+  echo 'unset NO_PROXY' >> "$CLAUDE_ENV_FILE"
+fi
+unset no_proxy
+unset NO_PROXY
+
 # Add mise to PATH for this session via CLAUDE_ENV_FILE
 if [ -n "$CLAUDE_ENV_FILE" ]; then
   echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$CLAUDE_ENV_FILE"


### PR DESCRIPTION
The remote environment has an HTTP proxy that handles both HTTP requests
and DNS resolution. However, `storage.googleapis.com` (where Go module
zip files are stored) was in the `no_proxy` list, preventing Go from
using the proxy for DNS lookups.

This caused Go module downloads to fail with:
  dial tcp: lookup storage.googleapis.com on 8.8.8.8:53: i/o timeout

Changes:
- Updated SessionStart hook to unset no_proxy/NO_PROXY environment vars
- Documented the issue and fix in CLAUDE.md under "Remote environment"
- Go builds now work without any manual intervention

The fix allows Go to use the HTTP proxy for all connections, including
DNS resolution, which is the only way DNS works in this environment.